### PR TITLE
Add test cases and fix memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,130 @@
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
 venv/
-.idea/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# End of https://www.gitignore.io/api/python

--- a/python/lru.py
+++ b/python/lru.py
@@ -62,13 +62,21 @@ class Lru:
         if self.end is None:
             self.end = self.start
 
-
     def printDoublyLinkedList(self):
         iterDL = self.start
         while iterDL is not None:
             print("({}->{})=>".format(iterDL.key, iterDL.value), end="")
             iterDL = iterDL.right
         print("None")
+
+    def getCacheInOrder(self, lastFirst=True):
+        res = []
+        iterDL = self.start if lastFirst else self.end
+        while iterDL is not None:
+            res.append(iterDL.value)
+            iterDL = iterDL.right if lastFirst else iterDL.left
+        return res
+
 
 if __name__ == '__main__':
     lru = Lru()

--- a/python/lru.py
+++ b/python/lru.py
@@ -35,6 +35,7 @@ class Lru:
         else:
             newEntry = Entry(key, value)
             if len(self.entryMap) == self.lruSize:
+                del self.entryMap[self.end.key]
                 self._removeEntry(self.end)
             self.entryMap[key] = newEntry
             self._addAtStart(newEntry)

--- a/python/test_lru.py
+++ b/python/test_lru.py
@@ -1,0 +1,87 @@
+import unittest
+
+from lru import Lru
+
+
+class LruTest(unittest.TestCase):
+    def test_init(self):
+        lru = Lru()
+        self.assertIsInstance(lru, Lru)
+
+    def test_add_int_key(self):
+        lru = Lru()
+        lru.addEntry(8, 16)
+        keys = list(lru.entryMap.keys())
+        self.assertEqual(keys, [8])
+
+    def test_add_str_key(self):
+        lru = Lru()
+        lru.addEntry('q29fk', 16)
+        keys = list(lru.entryMap.keys())
+        self.assertEqual(keys, ['q29fk'])
+
+    def test_get_entry(self):
+        lru = Lru()
+        lru.addEntry(8, 16)
+        val = lru.getEntry(8).value
+        self.assertEqual(val, 16)
+
+    def test_get_invalid_entry(self):
+        lru = Lru()
+        lru.addEntry(8, 16)
+        val = lru.getEntry(0)
+        self.assertEqual(val, -1)
+
+    def test_modify_entry(self):
+        lru = Lru()
+        lru.addEntry(8, 10)
+        lru.addEntry(8, 20)
+        lru.addEntry(8, 42)
+        val = lru.getEntry(8).value
+        self.assertEqual(val, 42)
+
+    def test_evict_cache(self):
+        lru = Lru()
+        lru.lruSize = 4  # assume lruSize = 4
+        lru.addEntry(1, 1)
+        lru.addEntry(2, 1)
+        lru.addEntry(3, 2)
+        lru.addEntry(4, 3)
+        lru.addEntry(5, 5)
+
+        vals = lru.getCacheInOrder()
+        self.assertEqual(vals, [5, 3, 2, 1])
+
+    def test_mixed_use_01(self):
+        lru = Lru()
+        lru.addEntry(0, 0)
+        lru.addEntry(1, 2)
+        lru.addEntry(2, 4)
+        lru.addEntry(3, 6)
+        node0 = lru.getEntry(0)
+        lru.addEntry(4, 8)
+
+        vals = lru.getCacheInOrder()
+        self.assertEqual(vals, [8, 0, 6, 4])
+        self.assertEqual(node0.value, 0)
+
+    def test_mixed_use_02(self):
+        lru = Lru()
+        lru.addEntry(0, 0)
+        lru.addEntry(1, 2)
+        lru.addEntry(2, 4)
+        lru.addEntry(3, 6)
+        lru.printDoublyLinkedList()
+        lru.getEntry(0)
+        lru.printDoublyLinkedList()
+        lru.addEntry(4, 8)
+        lru.printDoublyLinkedList()
+        node = lru.getEntry(1)
+        lru.printDoublyLinkedList()
+        lru.addEntry(5, 10)
+        lru.printDoublyLinkedList()
+
+        vals = lru.getCacheInOrder()
+        self.assertEqual(vals, [8, 0, 6, 4])
+        self.assertEqual(
+            node, -1, 'Node having key 1 should have been evicted')

--- a/python/test_lru.py
+++ b/python/test_lru.py
@@ -71,17 +71,12 @@ class LruTest(unittest.TestCase):
         lru.addEntry(1, 2)
         lru.addEntry(2, 4)
         lru.addEntry(3, 6)
-        lru.printDoublyLinkedList()
         lru.getEntry(0)
-        lru.printDoublyLinkedList()
         lru.addEntry(4, 8)
-        lru.printDoublyLinkedList()
         node = lru.getEntry(1)
-        lru.printDoublyLinkedList()
         lru.addEntry(5, 10)
-        lru.printDoublyLinkedList()
 
         vals = lru.getCacheInOrder()
-        self.assertEqual(vals, [8, 0, 6, 4])
+        self.assertEqual(vals, [10, 8, 0, 6])
         self.assertEqual(
             node, -1, 'Node having key 1 should have been evicted')


### PR DESCRIPTION
## Summary
To verify the implementation of LRU cache, this PR will
- add unit tests to LRU
- fix an issue where entries never get removed from the hash map, causing memory leak

## Issues
To reproduce the issue, run test case `test_mixed_use_02`
```python
lru = Lru() # lruSize = 4
lru.addEntry(0, 0)
lru.addEntry(1, 2)
lru.addEntry(2, 4)
lru.addEntry(3, 6)
lru.getEntry(0)
lru.addEntry(4, 8)
node = lru.getEntry(1)
lru.addEntry(5, 10)
```
Inspecting with `printDoublyLinkedList` gives the following snapshots
```
(0->0)=>None
(1->2)=>(0->0)=>None
(2->4)=>(1->2)=>(0->0)=>None
(3->6)=>(2->4)=>(1->2)=>(0->0)=>None
(0->0)=>(3->6)=>(2->4)=>(1->2)=>None
(4->8)=>(0->0)=>(3->6)=>(2->4)=>None
(1->2)=>(4->8)=>(0->0)=>(3->6)=>(2->4)=>None
(5->10)=>(1->2)=>(4->8)=>(0->0)=>(3->6)=>(2->4)=>None
```
What happened is that (1->2) had always been kept in the hash map so when we tried to get the entry that should no longer existed, the cache was able to bring back (1->2) to the head of the linked list by looking up the address from the hash map.

A possible solutions, done in this PR, is to delete the address of the least recently used entry from hash map when adding to the cache with full capacity.
```
(0->0)=>None
(1->2)=>(0->0)=>None
(2->4)=>(1->2)=>(0->0)=>None
(3->6)=>(2->4)=>(1->2)=>(0->0)=>None
(0->0)=>(3->6)=>(2->4)=>(1->2)=>None
(4->8)=>(0->0)=>(3->6)=>(2->4)=>None
(4->8)=>(0->0)=>(3->6)=>(2->4)=>None
(5->10)=>(4->8)=>(0->0)=>(3->6)=>None
```

## To-Do
- implement `printHashMap` to help visualize the state of the `entryMap`